### PR TITLE
Fix/implementation platform link

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/Implementation.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/Implementation.java
@@ -78,6 +78,9 @@ public class Implementation extends AlgorOrImpl implements ModelWithPublications
     private Set<ComputeResourceProperty> requiredComputeResourceProperties = new HashSet<>();
 
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(name = "software_platforms_implementations",
+            joinColumns = @JoinColumn(name = "implementation_id"),
+            inverseJoinColumns = @JoinColumn(name = "software_platform_id"))
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private Set<SoftwarePlatform> softwarePlatforms = new HashSet<>();

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/SoftwarePlatform.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/SoftwarePlatform.java
@@ -50,8 +50,10 @@ public class SoftwarePlatform extends HasId {
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    @ManyToMany(mappedBy = "softwarePlatforms",
-            cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @JoinTable(name = "software_platforms_compute_resources",
+            joinColumns = @JoinColumn(name = "software_platform_id"),
+            inverseJoinColumns = @JoinColumn(name = "implementation_id"))
     private Set<Implementation> implementations = new HashSet<>();
 
     public Set<Implementation> getImplementations() {

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/repository/ImplementationRepository.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/repository/ImplementationRepository.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 
 import org.planqk.atlas.core.model.Algorithm;
 import org.planqk.atlas.core.model.Implementation;
+import org.planqk.atlas.core.model.SoftwarePlatform;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +42,9 @@ public interface ImplementationRepository extends JpaRepository<Implementation, 
     boolean existsImplementationById(UUID id);
 
     Page<Implementation> findByImplementedAlgorithm(Algorithm implementedAlgorithm, Pageable pageable);
+
+    @Query("SELECT sp FROM Implementation i INNER JOIN i.softwarePlatforms sp WHERE i.id = :implId")
+    Page<SoftwarePlatform> findLinkedSoftwarePlatforms(@Param("implId") UUID implId, Pageable pageable);
 
     List<Implementation> findByImplementedAlgorithm(Algorithm implementedAlgorithm);
 

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
@@ -78,7 +78,6 @@ public class ImplementationServiceImpl implements ImplementationService {
 
     @Override
     public Page<SoftwarePlatform> findLinkedSoftwarePlatforms(UUID implId, Pageable p) {
-        // return softwarePlatformRepository.findSoftwarePlatformsByImplementationId(implId, p);
         return implementationRepository.findLinkedSoftwarePlatforms(implId, p);
     }
 

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
@@ -78,7 +78,8 @@ public class ImplementationServiceImpl implements ImplementationService {
 
     @Override
     public Page<SoftwarePlatform> findLinkedSoftwarePlatforms(UUID implId, Pageable p) {
-        return softwarePlatformRepository.findSoftwarePlatformsByImplementationId(implId, p);
+        // return softwarePlatformRepository.findSoftwarePlatformsByImplementationId(implId, p);
+        return implementationRepository.findLinkedSoftwarePlatforms(implId, p);
     }
 
     @Override


### PR DESCRIPTION
#### Short Description
Linking Software-Platforms with Implementations was not working properly and linked Software-Platforms were not returned while using the given endpoint.

#### Proposed Changes
**Fixes**: 
- Use JoinTable instead of mappedBy to link Software-Platforms and Implementations
- Move "GetLinkedSoftwarePlatforms" repository method to "ImplementationRepository"
