### PR TITLE
Versioning improvements

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/WebConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/WebConfiguration.java
@@ -20,15 +20,28 @@ package org.planqk.atlas.web;
 
 import java.util.List;
 
+import org.planqk.atlas.web.annotation.VersionedRequestHandlerMapping;
 import org.planqk.atlas.web.utils.ListParametersMethodArgumentResolver;
 
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
+    @Bean
+    public WebMvcRegistrations webMvcRegistrationsHandlerMapping() {
+        return new WebMvcRegistrations() {
+            @Override
+            public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+                return new VersionedRequestHandlerMapping();
+            }
+        };
+    }
+
     @Bean
     public ListParametersMethodArgumentResolver listParametersResolver() {
         return new ListParametersMethodArgumentResolver();

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/ApiVersion.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/ApiVersion.java
@@ -1,0 +1,18 @@
+package org.planqk.atlas.web.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add API versioning information to a controller or controller method.
+ *
+ * The specified version(s) are appended to the controller's base path (i.e.
+ * before the individual route paths).
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersion {
+    String[] value();
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMapping.java
@@ -1,0 +1,48 @@
+package org.planqk.atlas.web.annotation;
+
+import java.lang.reflect.Method;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Special implementation of RequestMappingHandlerMapping that optionally adds version suffixes to controller URLs.
+ */
+public class VersionedRequestHandlerMapping extends RequestMappingHandlerMapping {
+    /**
+     * Utility function to manually add routes from a given handler instance.
+     *
+     * Only for testing!
+     */
+    public void populateFromHandler(Object handler) {
+        detectHandlerMethods(handler);
+    }
+
+    @Override
+    protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
+        RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
+        if (info != null) {
+            ApiVersion methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, ApiVersion.class);
+            if (methodAnnotation != null) {
+                // Prepend our version mapping to the real method mapping.
+                info = createApiVersionInfo(methodAnnotation).combine(info);
+            }
+
+            ApiVersion typeAnnotation = AnnotatedElementUtils.findMergedAnnotation(handlerType, ApiVersion.class);
+            if (methodAnnotation == null && typeAnnotation != null) {
+                // Append our version mapping to the real controller mapping.
+                info = createApiVersionInfo(typeAnnotation).combine(info);
+            }
+        }
+        return info;
+    }
+
+    private RequestMappingInfo createApiVersionInfo(ApiVersion annotation) {
+        return new RequestMappingInfo(
+                new PatternsRequestCondition(annotation.value(), getUrlPathHelper(), getPathMatcher(),
+                        useSuffixPatternMatch(), useTrailingSlashMatch(), getFileExtensions()),
+                null, null, null, null, null, null);
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmController.java
@@ -42,6 +42,7 @@ import org.planqk.atlas.core.services.PublicationService;
 import org.planqk.atlas.core.services.SketchService;
 import org.planqk.atlas.core.services.TagService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.ApplicationAreaDto;
 import org.planqk.atlas.web.dtos.ComputeResourcePropertyDto;
@@ -99,7 +100,8 @@ import lombok.extern.slf4j.Slf4j;
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_ALGORITHM)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.ALGORITHMS)
+@RequestMapping("/" + Constants.ALGORITHMS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class AlgorithmController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmRelationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmRelationController.java
@@ -25,6 +25,7 @@ import org.planqk.atlas.core.model.AlgorithmRelation;
 import org.planqk.atlas.core.services.AlgorithmRelationService;
 import org.planqk.atlas.core.services.AlgorithmService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmRelationDto;
 import org.planqk.atlas.web.linkassembler.AlgorithmRelationAssembler;
 import org.planqk.atlas.web.utils.ControllerValidationUtils;
@@ -58,7 +59,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_ALGORITHM)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.ALGORITHMS + "/{algorithmId}/" + Constants.ALGORITHM_RELATIONS)
+@RequestMapping("/" + Constants.ALGORITHMS + "/{algorithmId}/" + Constants.ALGORITHM_RELATIONS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class AlgorithmRelationController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmRelationTypeController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/AlgorithmRelationTypeController.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.AlgorithmRelationType;
 import org.planqk.atlas.core.services.AlgorithmRelationTypeService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmRelationTypeDto;
 import org.planqk.atlas.web.linkassembler.AlgorithmRelationTypeAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -55,7 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_ALGORITHM_RELATION_TYPE)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.ALGORITHM_RELATION_TYPES)
+@RequestMapping("/" + Constants.ALGORITHM_RELATION_TYPES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class AlgorithmRelationTypeController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ApplicationAreaController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ApplicationAreaController.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.ApplicationArea;
 import org.planqk.atlas.core.services.ApplicationAreaService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ApplicationAreaDto;
 import org.planqk.atlas.web.linkassembler.ApplicationAreaAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -55,7 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_APPLICATION_AREAS)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.APPLICATION_AREAS)
+@RequestMapping("/" + Constants.APPLICATION_AREAS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ApplicationAreaController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/CloudServiceController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/CloudServiceController.java
@@ -25,6 +25,7 @@ import org.planqk.atlas.core.model.CloudService;
 import org.planqk.atlas.core.services.CloudServiceService;
 import org.planqk.atlas.core.services.LinkingService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.CloudServiceDto;
 import org.planqk.atlas.web.dtos.ComputeResourceDto;
 import org.planqk.atlas.web.dtos.SoftwarePlatformDto;
@@ -61,7 +62,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_EXECUTION_ENVIRONMENTS)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.CLOUD_SERVICES)
+@RequestMapping("/" + Constants.CLOUD_SERVICES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class CloudServiceController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ComputeResourceController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ComputeResourceController.java
@@ -26,6 +26,7 @@ import org.planqk.atlas.core.model.ComputeResourceProperty;
 import org.planqk.atlas.core.services.ComputeResourcePropertyService;
 import org.planqk.atlas.core.services.ComputeResourceService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.CloudServiceDto;
 import org.planqk.atlas.web.dtos.ComputeResourceDto;
 import org.planqk.atlas.web.dtos.ComputeResourcePropertyDto;
@@ -66,7 +67,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_EXECUTION_ENVIRONMENTS)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.COMPUTE_RESOURCES)
+@RequestMapping("/" + Constants.COMPUTE_RESOURCES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ComputeResourceController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ComputeResourcePropertyTypeController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ComputeResourcePropertyTypeController.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.ComputeResourcePropertyType;
 import org.planqk.atlas.core.services.ComputeResourcePropertyTypeService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ComputeResourcePropertyTypeDto;
 import org.planqk.atlas.web.linkassembler.ComputeResourcePropertyTypeAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -55,7 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_COMPUTE_RESOURCE_PROPERTY_TYPES)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.COMPUTE_RESOURCE_PROPERTY_TYPES)
+@RequestMapping("/" + Constants.COMPUTE_RESOURCE_PROPERTY_TYPES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ComputeResourcePropertyTypeController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/DiscussionCommentController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/DiscussionCommentController.java
@@ -27,6 +27,7 @@ import org.planqk.atlas.core.model.DiscussionComment;
 import org.planqk.atlas.core.services.DiscussionCommentService;
 import org.planqk.atlas.core.services.DiscussionTopicService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.DiscussionCommentDto;
 import org.planqk.atlas.web.linkassembler.DiscussionCommentAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -51,8 +52,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Hidden
 @Tag(name = Constants.TAG_DISCUSSION_TOPIC)
-@RestController("discussion-comment")
 @CrossOrigin(allowedHeaders = "*", origins = "*")
+@RestController("discussion-comment")
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class DiscussionCommentController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/DiscussionTopicController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/DiscussionTopicController.java
@@ -27,6 +27,7 @@ import org.planqk.atlas.core.model.DiscussionTopic;
 import org.planqk.atlas.core.services.DiscussionCommentService;
 import org.planqk.atlas.core.services.DiscussionTopicService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.DiscussionCommentDto;
 import org.planqk.atlas.web.dtos.DiscussionTopicDto;
 import org.planqk.atlas.web.linkassembler.DiscussionTopicAssembler;
@@ -60,7 +61,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Hidden
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_DISCUSSION_TOPIC)
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.DISCUSSION_TOPICS)
+@RequestMapping("/" + Constants.DISCUSSION_TOPICS)
+@ApiVersion("v1")
 @Slf4j
 @AllArgsConstructor
 @RestController

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationController.java
@@ -32,6 +32,7 @@ import org.planqk.atlas.core.services.PublicationService;
 import org.planqk.atlas.core.services.SoftwarePlatformService;
 import org.planqk.atlas.core.services.TagService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ComputeResourcePropertyDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.PublicationDto;
@@ -75,7 +76,8 @@ import org.springframework.web.bind.annotation.RestController;
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_ALGORITHM)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.ALGORITHMS + "/{algorithmId}/" + Constants.IMPLEMENTATIONS)
+@RequestMapping("/" + Constants.ALGORITHMS + "/{algorithmId}/" + Constants.IMPLEMENTATIONS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ImplementationController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationGlobalController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ImplementationGlobalController.java
@@ -21,6 +21,7 @@ package org.planqk.atlas.web.controller;
 
 import org.planqk.atlas.core.services.ImplementationService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.linkassembler.ImplementationAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -46,7 +47,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_IMPLEMENTATIONS)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.IMPLEMENTATIONS)
+@RequestMapping("/" + Constants.IMPLEMENTATIONS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ImplementationGlobalController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationController.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.PatternRelation;
 import org.planqk.atlas.core.services.PatternRelationService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.PatternRelationDto;
 import org.planqk.atlas.web.linkassembler.PatternRelationAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -54,7 +55,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_PATTERN_RELATION)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.PATTERN_RELATIONS)
+@RequestMapping("/" + Constants.PATTERN_RELATIONS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class PatternRelationController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationTypeController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PatternRelationTypeController.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.PatternRelationType;
 import org.planqk.atlas.core.services.PatternRelationTypeService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.PatternRelationTypeDto;
 import org.planqk.atlas.web.linkassembler.PatternRelationTypeAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -55,7 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_PATTERN_RELATION_TYPE)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.PATTERN_RELATION_TYPES)
+@RequestMapping("/" + Constants.PATTERN_RELATION_TYPES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class PatternRelationTypeController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ProblemTypeController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/ProblemTypeController.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import org.planqk.atlas.core.model.ProblemType;
 import org.planqk.atlas.core.services.ProblemTypeService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.ProblemTypeDto;
 import org.planqk.atlas.web.linkassembler.ProblemTypeAssembler;
 import org.planqk.atlas.web.utils.ListParameters;
@@ -55,7 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_PROBLEM_TYPE)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.PROBLEM_TYPES)
+@RequestMapping("/" + Constants.PROBLEM_TYPES)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class ProblemTypeController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PublicationController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/PublicationController.java
@@ -26,6 +26,7 @@ import org.planqk.atlas.core.services.ImplementationService;
 import org.planqk.atlas.core.services.LinkingService;
 import org.planqk.atlas.core.services.PublicationService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.PublicationDto;
@@ -65,7 +66,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @AllArgsConstructor
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.PUBLICATIONS)
+@RequestMapping("/" + Constants.PUBLICATIONS)
+@ApiVersion("v1")
 public class PublicationController {
 
     private final PublicationService publicationService;

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/RootController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/RootController.java
@@ -43,7 +43,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_ROOT)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/")
+@RequestMapping("/")
 @Slf4j
 public class RootController {
 

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/SoftwarePlatformController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/SoftwarePlatformController.java
@@ -26,6 +26,7 @@ import org.planqk.atlas.core.services.ImplementationService;
 import org.planqk.atlas.core.services.LinkingService;
 import org.planqk.atlas.core.services.SoftwarePlatformService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.CloudServiceDto;
 import org.planqk.atlas.web.dtos.ComputeResourceDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
@@ -64,7 +65,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = Constants.TAG_EXECUTION_ENVIRONMENTS)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.SOFTWARE_PLATFORMS)
+@RequestMapping("/" + Constants.SOFTWARE_PLATFORMS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class SoftwarePlatformController {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/TagController.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/controller/TagController.java
@@ -22,6 +22,7 @@ package org.planqk.atlas.web.controller;
 import org.planqk.atlas.core.model.Tag;
 import org.planqk.atlas.core.services.TagService;
 import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.annotation.ApiVersion;
 import org.planqk.atlas.web.dtos.AlgorithmDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.TagDto;
@@ -54,7 +55,8 @@ import org.springframework.web.bind.annotation.RestController;
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_TAG)
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
-@RequestMapping("/" + Constants.API_VERSION + "/" + Constants.TAGS)
+@RequestMapping("/" + Constants.TAGS)
+@ApiVersion("v1")
 @AllArgsConstructor
 @Slf4j
 public class TagController {

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMappingTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/annotation/VersionedRequestHandlerMappingTest.java
@@ -1,0 +1,46 @@
+package org.planqk.atlas.web.annotation;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.junit.Assert.assertEquals;
+
+class VersionedRequestHandlerMappingTest {
+
+    @RequestMapping("/unversioned")
+    static class Unversioned {
+        @RequestMapping("/versioned")
+        @ApiVersion("v1")
+        public void versioned() {
+        }
+    }
+
+    @RequestMapping("/versioned")
+    @ApiVersion("v1")
+    static class Versioned {
+        @RequestMapping("/unversioned")
+        public void unversioned() {
+        }
+
+        @RequestMapping("/versioned")
+        @ApiVersion({ "v1", "v2" })
+        public void versioned() {
+        }
+    }
+
+    private VersionedRequestHandlerMapping mapping = new VersionedRequestHandlerMapping();
+
+    @Test
+    void getMappingForMethod() throws NoSuchMethodException {
+        assertEquals(Set.of("/v1/unversioned/versioned"), getMethodPathMapping(Unversioned.class, "versioned"));
+        assertEquals(Set.of("/v1/versioned/unversioned"), getMethodPathMapping(Versioned.class, "unversioned"));
+        assertEquals(Set.of("/v1/versioned/versioned", "/v2/versioned/versioned"),
+                getMethodPathMapping(Versioned.class, "versioned"));
+    }
+
+    private Set<String> getMethodPathMapping(Class<?> clazz, String methodName) throws NoSuchMethodException {
+        return mapping.getMappingForMethod(clazz.getMethod(methodName), clazz).getPatternsCondition().getPatterns();
+    }
+}

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmRelationTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmRelationTypeControllerTest.java
@@ -30,6 +30,7 @@ import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.AlgorithmRelationDto;
 import org.planqk.atlas.web.dtos.AlgorithmRelationTypeDto;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
 import org.planqk.atlas.web.utils.ListParameters;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
@@ -52,20 +53,18 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.fromMethodCall;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @WebMvcTest(AlgorithmRelationTypeController.class)
 @ExtendWith(MockitoExtension.class)
@@ -79,9 +78,10 @@ public class AlgorithmRelationTypeControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
 
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
     private final int page = 0;
     private final int size = 2;
@@ -108,8 +108,8 @@ public class AlgorithmRelationTypeControllerTest {
         AlgorithmRelationTypeDto algorithmRelationTypeDto = new AlgorithmRelationTypeDto();
         algorithmRelationTypeDto.setId(UUID.randomUUID());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .createAlgorithmRelationType(null)).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .createAlgorithmRelationType(null));
         mockMvc.perform(post(url)
                 .content(mapper.writeValueAsString(algorithmRelationTypeDto))
                 .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
@@ -122,8 +122,8 @@ public class AlgorithmRelationTypeControllerTest {
         var id = algoRelationType1Dto.getId();
         algoRelationType1Dto.setId(null);
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .createAlgorithmRelationType(null)).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .createAlgorithmRelationType(null));
         MvcResult result = mockMvc.perform(post(url)
                 .content(mapper.writeValueAsString(algoRelationType1Dto))
                 .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
@@ -140,8 +140,8 @@ public class AlgorithmRelationTypeControllerTest {
         AlgorithmRelationTypeDto algorithmRelationTypeDto = new AlgorithmRelationTypeDto();
         algorithmRelationTypeDto.setId(UUID.randomUUID());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .updateAlgorithmRelationType(UUID.randomUUID(), null)).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .updateAlgorithmRelationType(UUID.randomUUID(), null));
         mockMvc.perform(put(url)
                 .content(mapper.writeValueAsString(algorithmRelationTypeDto)).contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
@@ -151,8 +151,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void updateAlgoRelationType_returnOk() throws Exception {
         when(algorithmRelationTypeService.update(any())).thenReturn(algorithmRelationType1);
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .updateAlgorithmRelationType(UUID.randomUUID(), null)).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .updateAlgorithmRelationType(UUID.randomUUID(), null));
         MvcResult result = mockMvc
                 .perform(put(url)
                         .content(mapper.writeValueAsString(algoRelationType1Dto))
@@ -169,8 +169,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void getAlgoRelationTypes_withEmptyAlgoRelationTypeList() throws Exception {
         when(algorithmRelationTypeService.findAll(any())).thenReturn(Page.empty());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .getAlgorithmRelationTypes(ListParameters.getDefault())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .getAlgorithmRelationTypes(ListParameters.getDefault()));
         MvcResult result = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
 
@@ -191,8 +191,8 @@ public class AlgorithmRelationTypeControllerTest {
 
         when(algorithmRelationTypeService.findAll(any())).thenReturn(algoRelationPage);
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .getAlgorithmRelationTypes(ListParameters.getDefault())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .getAlgorithmRelationTypes(ListParameters.getDefault()));
 
         MvcResult result = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
@@ -206,8 +206,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void getAlgoRelationTypeById_returnNotFound() throws Exception {
         doThrow(new NoSuchElementException()).when(algorithmRelationTypeService).findById(any());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .getAlgorithmRelationType(algorithmRelationType1.getId())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .getAlgorithmRelationType(algorithmRelationType1.getId()));
         mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
@@ -216,8 +216,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void getAlgoRelationTypeById_returnAlgoRelationType() throws Exception {
         when(algorithmRelationTypeService.findById(any())).thenReturn(algorithmRelationType1);
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .getAlgorithmRelationType(algorithmRelationType1.getId())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .getAlgorithmRelationType(algorithmRelationType1.getId()));
 
         MvcResult result = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
@@ -233,8 +233,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void deleteAlgoRelationType_returnNotFound() throws Exception {
         doThrow(NoSuchElementException.class).when(algorithmRelationTypeService).delete(any());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .deleteAlgorithmRelationType(algorithmRelationType1.getId())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .deleteAlgorithmRelationType(algorithmRelationType1.getId()));
 
         mockMvc.perform(delete(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
@@ -244,8 +244,8 @@ public class AlgorithmRelationTypeControllerTest {
     public void deleteAlgoRelationType_returnOk() throws Exception {
         doNothing().when(algorithmRelationTypeService).delete(any());
 
-        var url = fromMethodCall(uriBuilder, on(AlgorithmRelationTypeController.class)
-                .deleteAlgorithmRelationType(algorithmRelationType1.getId())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(AlgorithmRelationTypeController.class)
+                .deleteAlgorithmRelationType(algorithmRelationType1.getId()));
         mockMvc.perform(delete(url).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
     }

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputeResourceControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputeResourceControllerTest.java
@@ -30,10 +30,11 @@ import org.planqk.atlas.core.model.ComputeResourcePropertyDataType;
 import org.planqk.atlas.core.model.ComputeResourcePropertyType;
 import org.planqk.atlas.core.services.ComputeResourcePropertyService;
 import org.planqk.atlas.core.services.ComputeResourceService;
-import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.ComputeResourceDto;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
+import org.planqk.atlas.web.utils.ListParameters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -49,13 +50,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -63,8 +64,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.fromMethodCall;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @WebMvcTest(ComputeResourceController.class)
 @ExtendWith(MockitoExtension.class)
@@ -79,8 +78,10 @@ public class ComputeResourceControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
+
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
     private final int page = 0;
     private final int size = 2;
@@ -93,9 +94,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).createComputeResource(null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).createComputeResource(null)
+                        )
                 ).content(mapper.writeValueAsString(resource))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -115,9 +116,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).createComputeResource(null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).createComputeResource(null)
+                        )
                 ).content(mapper.writeValueAsString(resource))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -137,9 +138,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
+                        )
                 ).content(mapper.writeValueAsString(resource))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -153,9 +154,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
+                        )
                 ).content(mapper.writeValueAsString(resource))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -176,9 +177,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).updateComputeResource(UUID.randomUUID(), null)
+                        )
                 ).content(mapper.writeValueAsString(resource))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -198,9 +199,9 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).getComputeResource(resource.getId())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).getComputeResource(resource.getId())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(resource.getId().toString()))
@@ -213,27 +214,25 @@ public class ComputeResourceControllerTest {
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).getComputeResource(UUID.randomUUID())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).getComputeResource(UUID.randomUUID())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputeResources_empty() throws Exception {
         doReturn(Page.empty()).when(computeResourceService).findAll(any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class)
-                                        .getComputeResources(null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class)
+                                        .getComputeResources(
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -243,20 +242,17 @@ public class ComputeResourceControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void searchComputeResources_empty() throws Exception {
         doReturn(Page.empty()).when(computeResourceService).searchAllByName(any(), any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class)
-                                        .getComputeResources(null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .queryParam(Constants.SEARCH, "hello")
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class)
+                                        .getComputeResources(
+                                                new ListParameters(pageable, "hello"))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -266,7 +262,6 @@ public class ComputeResourceControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputeResources_notEmpty() throws Exception {
         var inputList = new ArrayList<ComputeResource>();
         for (int i = 0; i < 50; i++) {
@@ -279,13 +274,12 @@ public class ComputeResourceControllerTest {
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class)
-                                        .getComputeResources(null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class)
+                                        .getComputeResources(
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var dtoElements = ObjectMapperUtils.mapResponseToList(
@@ -301,20 +295,18 @@ public class ComputeResourceControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputationResourceProperties_empty() throws Exception {
         doReturn(Page.empty()).when(computeResourcePropertyService)
                 .findComputeResourcePropertiesOfComputeResource(any(), any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class)
-                                        .getComputeResourcePropertiesOfComputeResource(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class)
+                                        .getComputeResourcePropertiesOfComputeResource(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -324,7 +316,6 @@ public class ComputeResourceControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputationResourceProperties_notEmpty() throws Exception {
         var inputList = new ArrayList<ComputeResourceProperty>();
         var type = new ComputeResourcePropertyType();
@@ -343,13 +334,12 @@ public class ComputeResourceControllerTest {
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class)
-                                        .getComputeResourcePropertiesOfComputeResource(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class)
+                                        .getComputeResourcePropertiesOfComputeResource(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var dtoElements = ObjectMapperUtils.mapResponseToList(
@@ -369,9 +359,9 @@ public class ComputeResourceControllerTest {
         doThrow(new NoSuchElementException()).when(computeResourceService).delete(any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
@@ -381,9 +371,9 @@ public class ComputeResourceControllerTest {
         doNothing().when(computeResourceService).delete(any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNoContent());
     }
@@ -393,9 +383,9 @@ public class ComputeResourceControllerTest {
         doThrow(new EntityReferenceConstraintViolationException("")).when(computeResourceService).delete(any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(ComputeResourceController.class).deleteComputeResource(UUID.randomUUID())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isBadRequest());
     }

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputeResourcePropertyTypeControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ComputeResourcePropertyTypeControllerTest.java
@@ -31,6 +31,8 @@ import org.planqk.atlas.core.services.ComputeResourcePropertyTypeService;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.ComputeResourcePropertyTypeDto;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
+import org.planqk.atlas.web.utils.ListParameters;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,18 +46,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.fromMethodCall;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @WebMvcTest(ComputeResourcePropertyTypeController.class)
 @ExtendWith(MockitoExtension.class)
@@ -70,39 +70,40 @@ public class ComputeResourcePropertyTypeControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
 
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
     @Test
     void deleteType_returnNoContent() throws Exception {
         doNothing().when(computeResourcePropertyTypeService).delete(any());
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .deleteComputingResourcePropertyType(UUID.randomUUID())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .deleteComputingResourcePropertyType(UUID.randomUUID()));
         mockMvc.perform(delete(url)).andExpect(status().isNoContent());
     }
 
     @Test
     void deleteType_returnBadRequest() throws Exception {
         doThrow(new EntityReferenceConstraintViolationException("")).when(computeResourcePropertyTypeService).delete(any());
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .deleteComputingResourcePropertyType(UUID.randomUUID())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .deleteComputingResourcePropertyType(UUID.randomUUID()));
         mockMvc.perform(delete(url)).andExpect(status().isBadRequest());
     }
 
     @Test
     void deleteType_returnNotFound() throws Exception {
         doThrow(new NoSuchElementException()).when(computeResourcePropertyTypeService).delete(any());
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .deleteComputingResourcePropertyType(UUID.randomUUID())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .deleteComputingResourcePropertyType(UUID.randomUUID()));
         mockMvc.perform(delete(url)).andExpect(status().isNotFound());
     }
 
     @Test
     void getType_returnNotFound() throws Exception {
         when(computeResourcePropertyTypeService.findById(any())).thenThrow(new NoSuchElementException());
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .getComputingResourcePropertyType(UUID.randomUUID())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .getComputingResourcePropertyType(UUID.randomUUID()));
         mockMvc.perform(get(url)).andExpect(status().isNotFound());
     }
 
@@ -115,8 +116,8 @@ public class ComputeResourcePropertyTypeControllerTest {
         sampleType.setDescription("Test");
 
         when(computeResourcePropertyTypeService.findById(any())).thenReturn(sampleType);
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .getComputingResourcePropertyType(UUID.randomUUID())).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .getComputingResourcePropertyType(UUID.randomUUID()));
         var result = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
 
         var dto = mapper.readValue(
@@ -144,8 +145,8 @@ public class ComputeResourcePropertyTypeControllerTest {
         }
 
         when(computeResourcePropertyTypeService.findAll(any())).thenReturn(new PageImpl<>(types));
-        var url = fromMethodCall(uriBuilder, on(ComputeResourcePropertyTypeController.class)
-                .getResourcePropertyTypes(null)).toUriString();
+        var url = linkBuilderService.urlStringTo(methodOn(ComputeResourcePropertyTypeController.class)
+                .getResourcePropertyTypes(ListParameters.getDefault()));
         var result = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
 
         var resultList = ObjectMapperUtils.mapResponseToList(

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/DiscussionCommentControllerTest.java
@@ -34,6 +34,7 @@ import org.planqk.atlas.web.Constants;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.dtos.DiscussionCommentDto;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -54,7 +55,6 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,9 +80,10 @@ public class DiscussionCommentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
 
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
     private final int page = 0;
     private final int size = 1;

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/ImplementationControllerTest.java
@@ -33,6 +33,7 @@ import org.planqk.atlas.core.services.SoftwarePlatformService;
 import org.planqk.atlas.core.services.TagService;
 import org.planqk.atlas.web.controller.util.ObjectMapperUtils;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +43,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -70,9 +70,10 @@ public class ImplementationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
 
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
 //    @Test
 //    public void getOneImplForAlgo() throws Exception {

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/RootControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/RootControllerTest.java
@@ -45,7 +45,7 @@ public class RootControllerTest {
 
     @Test
     public void testGetHateoasLinks() throws Exception {
-        MvcResult result = mockMvc.perform(get("/" + Constants.API_VERSION + "/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+        MvcResult result = mockMvc.perform(get("/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
                 .andReturn();
 
         var responseObject = new JSONObject(result.getResponse().getContentAsString());

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/SoftwarePlatformControllerTest.java
@@ -40,6 +40,8 @@ import org.planqk.atlas.web.dtos.ComputeResourceDto;
 import org.planqk.atlas.web.dtos.ImplementationDto;
 import org.planqk.atlas.web.dtos.SoftwarePlatformDto;
 import org.planqk.atlas.web.linkassembler.EnableLinkAssemblers;
+import org.planqk.atlas.web.linkassembler.LinkBuilderService;
+import org.planqk.atlas.web.utils.ListParameters;
 import org.planqk.atlas.web.utils.ModelMapperUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -60,7 +62,6 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -69,13 +70,12 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.fromMethodCall;
-import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @WebMvcTest(controllers = {SoftwarePlatformController.class})
 @ExtendWith( {MockitoExtension.class})
@@ -87,16 +87,20 @@ public class SoftwarePlatformControllerTest {
     private final int size = 10;
     private final Pageable pageable = PageRequest.of(page, size);
     private final String softwarePlatformDtoJSONName = "softwarePlatforms";
+
     @MockBean
     private SoftwarePlatformService softwarePlatformService;
     @MockBean
     private LinkingService linkingService;
     @MockBean
     private ImplementationService implementationService;
+
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private LinkBuilderService linkBuilderService;
+
     private final ObjectMapper mapper = ObjectMapperUtils.newTestMapper();
-    private final UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath("/");
 
     @Test
     public void addSoftwarePlatform_returnBadRequest() throws Exception {
@@ -105,9 +109,9 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).createSoftwarePlatform(null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).createSoftwarePlatform(null)
+                        )
                 ).content(mapper.writeValueAsString(softwarePlatform))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -124,9 +128,9 @@ public class SoftwarePlatformControllerTest {
 
         MvcResult result = mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).createSoftwarePlatform(null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).createSoftwarePlatform(null)
+                        )
                 ).content(mapper.writeValueAsString(softwarePlatformDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -148,12 +152,10 @@ public class SoftwarePlatformControllerTest {
         MvcResult result = mockMvc
                 .perform(
                         get(
-                                fromMethodCall(uriBuilder,
-                                        on(SoftwarePlatformController.class).getSoftwarePlatforms(null)
-                                ).toUriString()
-                        ).queryParam(Constants.PAGE, Integer.toString(page))
-                                .queryParam(Constants.SIZE, Integer.toString(size))
-                                .accept(MediaType.APPLICATION_JSON))
+                                linkBuilderService.urlStringTo(
+                                        methodOn(SoftwarePlatformController.class).getSoftwarePlatforms(new ListParameters(pageable, null))
+                                )
+                        ).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(result.getResponse().getContentAsString());
@@ -170,13 +172,10 @@ public class SoftwarePlatformControllerTest {
         MvcResult result = mockMvc
                 .perform(
                         get(
-                                fromMethodCall(uriBuilder,
-                                        on(SoftwarePlatformController.class).getSoftwarePlatforms(null)
-                                ).toUriString()
-                        ).queryParam(Constants.PAGE, Integer.toString(page))
-                                .queryParam(Constants.SIZE, Integer.toString(size))
-                                .queryParam(Constants.SEARCH, "hellp")
-                                .accept(MediaType.APPLICATION_JSON))
+                                linkBuilderService.urlStringTo(
+                                        methodOn(SoftwarePlatformController.class).getSoftwarePlatforms(new ListParameters(pageable, "hellp"))
+                                )
+                        ).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(result.getResponse().getContentAsString());
@@ -201,12 +200,10 @@ public class SoftwarePlatformControllerTest {
         MvcResult result = mockMvc
                 .perform(
                         get(
-                                fromMethodCall(uriBuilder,
-                                        on(SoftwarePlatformController.class).getSoftwarePlatforms(null)
-                                ).toUriString()
-                        ).queryParam(Constants.PAGE, Integer.toString(page))
-                                .queryParam(Constants.SIZE, Integer.toString(size))
-                                .accept(MediaType.APPLICATION_JSON))
+                                linkBuilderService.urlStringTo(
+                                        methodOn(SoftwarePlatformController.class).getSoftwarePlatforms(new ListParameters(pageable, null))
+                                )
+                        ).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
 
         JSONObject rootObject = new JSONObject(result.getResponse().getContentAsString());
@@ -238,12 +235,10 @@ public class SoftwarePlatformControllerTest {
         MvcResult result = mockMvc
                 .perform(
                         get(
-                                fromMethodCall(uriBuilder,
-                                        on(SoftwarePlatformController.class).getSoftwarePlatforms(null)
-                                ).toUriString()
-                        ).queryParam(Constants.PAGE, Integer.toString(page))
-                                .queryParam(Constants.SIZE, Integer.toString(size))
-                                .accept(MediaType.APPLICATION_JSON))
+                                linkBuilderService.urlStringTo(
+                                        methodOn(SoftwarePlatformController.class).getSoftwarePlatforms(new ListParameters(pageable, null))
+                                )
+                        ).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
 
         JSONObject rootObject = new JSONObject(result.getResponse().getContentAsString());
@@ -263,9 +258,9 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).getSoftwarePlatform(testId)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).getSoftwarePlatform(testId)
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
@@ -279,9 +274,9 @@ public class SoftwarePlatformControllerTest {
 
         MvcResult result = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).getSoftwarePlatform(softwarePlatform.getId())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).getSoftwarePlatform(softwarePlatform.getId())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
@@ -299,9 +294,9 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).deleteSoftwarePlatform(UUID.randomUUID())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).deleteSoftwarePlatform(UUID.randomUUID())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
@@ -315,9 +310,9 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class).deleteSoftwarePlatform(softwarePlatform.getId())
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class).deleteSoftwarePlatform(softwarePlatform.getId())
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNoContent());
     }
@@ -335,10 +330,10 @@ public class SoftwarePlatformControllerTest {
         doReturn(returnValue).when(softwarePlatformService).update(any());
         var mvcResult = mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .updateSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsBytes(sampleInput))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -356,10 +351,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new NoSuchElementException()).when(softwarePlatformService).update(any());
         mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .updateSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsBytes(sampleInput))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -374,10 +369,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new NoSuchElementException()).when(softwarePlatformService).update(any());
         mockMvc.perform(
                 put(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .updateSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsBytes(sampleInput))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -385,16 +380,16 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listImplementations_returnNotFound() throws Exception {
         doThrow(new NoSuchElementException()).when(softwarePlatformService).findLinkedImplementations(any(), any());
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
                 ).queryParam(Constants.PAGE, Integer.toString(page))
                         .queryParam(Constants.SIZE, Integer.toString(size))
                         .accept(MediaType.APPLICATION_JSON)
@@ -402,53 +397,47 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listCloudServices_returnNotFound() throws Exception {
         doThrow(new NoSuchElementException()).when(softwarePlatformService).findLinkedCloudServices(any(), any());
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputeResources_returnNotFound() throws Exception {
         doThrow(new NoSuchElementException()).when(softwarePlatformService).findLinkedComputeResources(any(), any());
 
         mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listImplementations_empty() throws Exception {
         doReturn(Page.empty()).when(softwarePlatformService).findLinkedImplementations(any(), any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -458,19 +447,17 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listCloudServices_empty() throws Exception {
         doReturn(Page.empty()).when(softwarePlatformService).findLinkedCloudServices(any(), any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -480,19 +467,17 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputeResources_empty() throws Exception {
         doReturn(Page.empty()).when(softwarePlatformService).findLinkedComputeResources(any(), any());
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var page = ObjectMapperUtils.getPageInfo(mvcResult.getResponse().getContentAsString());
@@ -502,7 +487,6 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listImplementations_notEmpty() throws Exception {
         var inputList = new ArrayList<Implementation>();
         var algo = new Algorithm();
@@ -518,13 +502,12 @@ public class SoftwarePlatformControllerTest {
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getImplementationsOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var dtoElements = ObjectMapperUtils.mapResponseToList(
@@ -540,7 +523,6 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listCloudServices_notEmpty() throws Exception {
         var inputList = new ArrayList<CloudService>();
         for (int i = 0; i < 50; i++) {
@@ -553,13 +535,12 @@ public class SoftwarePlatformControllerTest {
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
-                ).queryParam(Constants.PAGE, Integer.toString(page))
-                        .queryParam(Constants.SIZE, Integer.toString(size))
-                        .accept(MediaType.APPLICATION_JSON)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getCloudServicesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
+                ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk()).andReturn();
 
         var dtoElements = ObjectMapperUtils.mapResponseToList(
@@ -575,7 +556,6 @@ public class SoftwarePlatformControllerTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
     void listComputeResources_notEmpty() throws Exception {
         var inputList = new ArrayList<ComputeResource>();
         for (int i = 0; i < 50; i++) {
@@ -588,10 +568,11 @@ public class SoftwarePlatformControllerTest {
 
         var mvcResult = mockMvc.perform(
                 get(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
-                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(), null)
-                        ).toUriString()
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
+                                        .getComputeResourcesOfSoftwarePlatform(UUID.randomUUID(),
+                                                new ListParameters(pageable, null))
+                        )
                 ).queryParam(Constants.PAGE, Integer.toString(page))
                         .queryParam(Constants.SIZE, Integer.toString(size))
                         .accept(MediaType.APPLICATION_JSON)
@@ -617,7 +598,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .addImplementationReferenceToSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isOk());
 //    }
@@ -630,7 +611,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .addImplementationReferenceToSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isNotFound());
 //    }
@@ -643,7 +624,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .addImplementationReferenceToSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isBadRequest());
 //    }
@@ -656,7 +637,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .deleteImplementationReferenceFromSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isOk());
 //    }
@@ -669,7 +650,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .deleteImplementationReferenceFromSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isNotFound());
 //    }
@@ -682,7 +663,7 @@ public class SoftwarePlatformControllerTest {
 //                        fromMethodCall(uriBuilder,
 //                                on(SoftwarePlatformController.class)
 //                                        .deleteImplementationReferenceFromSoftwarePlatform(UUID.randomUUID(), UUID.randomUUID())
-//                        ).toUriString()
+//                        )
 //                ).accept(MediaType.APPLICATION_JSON)
 //        ).andExpect(status().isBadRequest());
 //    }
@@ -697,10 +678,10 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndComputeResource(UUID.randomUUID(), new ComputeResourceDto())
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsString(cloudServiceDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -712,10 +693,10 @@ public class SoftwarePlatformControllerTest {
         doNothing().when(linkingService).unlinkSoftwarePlatformAndComputeResource(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndComputeResource(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNoContent());
     }
@@ -730,10 +711,10 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndComputeResource(UUID.randomUUID(), new ComputeResourceDto())
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsString(cloudServiceDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -745,10 +726,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new NoSuchElementException()).when(linkingService).unlinkSoftwarePlatformAndComputeResource(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndComputeResource(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
@@ -758,10 +739,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new EntityReferenceConstraintViolationException("")).when(linkingService).linkSoftwarePlatformAndComputeResource(any(), any());
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndComputeResource(UUID.randomUUID(), new ComputeResourceDto())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isBadRequest());
     }
@@ -771,10 +752,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new EntityReferenceConstraintViolationException("")).when(linkingService).unlinkSoftwarePlatformAndComputeResource(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndComputeResource(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isBadRequest());
     }
@@ -789,10 +770,10 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndCloudService(UUID.randomUUID(), null)
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsString(cloudServiceDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -804,10 +785,10 @@ public class SoftwarePlatformControllerTest {
         doNothing().when(linkingService).unlinkSoftwarePlatformAndCloudService(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndCloudService(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNoContent());
     }
@@ -822,10 +803,10 @@ public class SoftwarePlatformControllerTest {
 
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndCloudService(UUID.randomUUID(), new CloudServiceDto())
-                        ).toUriString()
+                        )
                 ).content(mapper.writeValueAsString(cloudServiceDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
@@ -837,10 +818,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new NoSuchElementException()).when(linkingService).unlinkSoftwarePlatformAndCloudService(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndCloudService(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isNotFound());
     }
@@ -850,10 +831,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new EntityReferenceConstraintViolationException("")).when(linkingService).linkSoftwarePlatformAndCloudService(any(), any());
         mockMvc.perform(
                 post(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .linkSoftwarePlatformAndCloudService(UUID.randomUUID(), new CloudServiceDto())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isBadRequest());
     }
@@ -863,10 +844,10 @@ public class SoftwarePlatformControllerTest {
         doThrow(new EntityReferenceConstraintViolationException("")).when(linkingService).unlinkSoftwarePlatformAndCloudService(any(), any());
         mockMvc.perform(
                 delete(
-                        fromMethodCall(uriBuilder,
-                                on(SoftwarePlatformController.class)
+                        linkBuilderService.urlStringTo(
+                                methodOn(SoftwarePlatformController.class)
                                         .unlinkSoftwarePlatformAndCloudService(UUID.randomUUID(), UUID.randomUUID())
-                        ).toUriString()
+                        )
                 ).accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isBadRequest());
     }

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/DummyController.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
+import org.planqk.atlas.web.annotation.ApiVersion;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/controller")
+@ApiVersion("v1")
 public class DummyController {
     @GetMapping("/test")
     public HttpEntity<Void> test() {

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceIntegrationTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceIntegrationTest.java
@@ -18,12 +18,13 @@
  *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
-import org.planqk.atlas.web.Constants;
+import org.planqk.atlas.web.WebConfiguration;
 import org.planqk.atlas.web.controller.RootController;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.IanaLinkRelations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,6 +32,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @WebMvcTest( {RootController.class, DummyController.class})
 @EnableLinkAssemblers
+@Import(WebConfiguration.class)
 public class LinkBuilderServiceIntegrationTest {
     @Autowired
     private LinkBuilderService service;
@@ -39,6 +41,13 @@ public class LinkBuilderServiceIntegrationTest {
     public void resolvesAsUnversioned() {
         var link = service.linkTo(methodOn(RootController.class).root()).withSelfRel();
         assertEquals(IanaLinkRelations.SELF, link.getRel());
-        assertEquals("/" + Constants.API_VERSION + "/", link.getHref());
+        assertEquals("/", link.getHref());
+    }
+
+    @Test
+    public void resolvesAsVersioned() {
+        var link = service.linkTo(methodOn(DummyController.class).test()).withSelfRel();
+        assertEquals(IanaLinkRelations.SELF, link.getRel());
+        assertEquals("/v1/controller/test", link.getHref());
     }
 }

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/linkassembler/LinkBuilderServiceTest.java
@@ -18,19 +18,27 @@
  *******************************************************************************/
 package org.planqk.atlas.web.linkassembler;
 
+import org.planqk.atlas.web.annotation.VersionedRequestHandlerMapping;
+import org.planqk.atlas.web.utils.ListParametersMethodArgumentResolver;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.http.HttpEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 public class LinkBuilderServiceTest {
-    private final Controller c = new Controller();
-    private RequestMappingHandlerMapping mappings = new RequestMappingHandlerMapping();
-    private LinkBuilderService service = new LinkBuilderService(mappings);
+    private VersionedRequestHandlerMapping mappings = new VersionedRequestHandlerMapping();
+    private ListParametersMethodArgumentResolver listParamResolver = new ListParametersMethodArgumentResolver();
+    private LinkBuilderService service = new LinkBuilderService(listParamResolver, mappings);
+
+    @BeforeEach
+    public void setupMappings() {
+        mappings.populateFromHandler(new Controller());
+    }
 
     @Test
     public void invalid() {


### PR DESCRIPTION
Like last time, add a custom annotation for versioning information.
This time, the version is added as prefix to the URL's path.

Additionally, replace hardcoded URLs in controller tests with invocations of `LinkBuilderService#urlTo`
To make this more streamlined, add support for automatically turning ListParameters into query parameters.

Right now, there's no support for automatically choosing the highest version when using an unversioned endpoint.

**Fixes**: UST-QuAntiL/q-tal#44
