### PR TITLE
delete unnecessary setSketches() from update algorithm. The relation …

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmServiceImpl.java
@@ -106,8 +106,6 @@ public class AlgorithmServiceImpl implements AlgorithmService {
     public Algorithm update(@NonNull Algorithm algorithm) {
         Algorithm persistedAlgorithm = findById(algorithm.getId());
 
-        persistedAlgorithm.setSketches(algorithm.getSketches());
-
         persistedAlgorithm.setName(algorithm.getName());
         persistedAlgorithm.setAcronym(algorithm.getAcronym());
         persistedAlgorithm.setIntent(algorithm.getIntent());


### PR DESCRIPTION
…between the algorithms and sketches is made by the sketch entity

#### Short Description
delete unnecessary setSketches() from update algorithm. The relation between the algorithms and sketches is made by the sketch entity

#### Proposed Changes

  * delete unnecessary setSketches() from update algorithm

