### PR TITLE
Fix ConcurrentModificationException when deleting entities

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmServiceImpl.java
@@ -37,6 +37,7 @@ import org.planqk.atlas.core.repository.ComputeResourcePropertyRepository;
 import org.planqk.atlas.core.repository.PatternRelationRepository;
 import org.planqk.atlas.core.repository.ProblemTypeRepository;
 import org.planqk.atlas.core.repository.PublicationRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -68,7 +69,6 @@ public class AlgorithmServiceImpl implements AlgorithmService {
 
     private final PatternRelationService patternRelationService;
     private final PatternRelationRepository patternRelationRepository;
-
 
     @Override
     @Transactional
@@ -145,19 +145,19 @@ public class AlgorithmServiceImpl implements AlgorithmService {
                 patternRelation -> patternRelationService.delete(patternRelation.getId()));
 
         // remove links to publications
-        algorithm.getPublications().forEach(
+        CollectionUtils.forEachOnCopy(algorithm.getPublications(),
                 publication -> publication.removeAlgorithm(algorithm));
 
         // remove links to application areas
-        algorithm.getApplicationAreas().forEach(
+        CollectionUtils.forEachOnCopy(algorithm.getApplicationAreas(),
                 applicationArea -> applicationArea.removeAlgorithm(algorithm));
 
         // remove links to problem types
-        algorithm.getProblemTypes().forEach(
+        CollectionUtils.forEachOnCopy(algorithm.getProblemTypes(),
                 problemType -> problemType.removeAlgorithm(algorithm));
 
         // remove link to tag
-        algorithm.getTags().forEach(tag -> tag.removeAlgorithm(algorithm));
+        CollectionUtils.forEachOnCopy(algorithm.getTags(), tag -> tag.removeAlgorithm(algorithm));
     }
 
     @Override
@@ -202,7 +202,7 @@ public class AlgorithmServiceImpl implements AlgorithmService {
 
         if (!ServiceUtils.containsElementWithId(algorithm.getPublications(), publicationId)) {
             throw new NoSuchElementException("Publication with ID \"" + publicationId
-                    + "\" is not linked to Algorithm with ID \"" + algorithmId +  "\"");
+                    + "\" is not linked to Algorithm with ID \"" + algorithmId + "\"");
         }
     }
 
@@ -213,7 +213,7 @@ public class AlgorithmServiceImpl implements AlgorithmService {
 
         if (!ServiceUtils.containsElementWithId(algorithm.getProblemTypes(), problemTypeId)) {
             throw new NoSuchElementException("ProblemType with ID \"" + problemTypeId
-                    + "\" is not linked to Algorithm with ID \"" + algorithmId +  "\"");
+                    + "\" is not linked to Algorithm with ID \"" + algorithmId + "\"");
         }
     }
 
@@ -224,7 +224,7 @@ public class AlgorithmServiceImpl implements AlgorithmService {
 
         if (!ServiceUtils.containsElementWithId(algorithm.getApplicationAreas(), applicationAreaId)) {
             throw new NoSuchElementException("ApplicationArea with ID \"" + applicationAreaId
-                    + "\" is not linked to Algorithm with ID \"" + algorithmId +  "\"");
+                    + "\" is not linked to Algorithm with ID \"" + algorithmId + "\"");
         }
     }
 

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ApplicationAreaServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ApplicationAreaServiceImpl.java
@@ -27,6 +27,7 @@ import javax.transaction.Transactional;
 import org.planqk.atlas.core.exceptions.EntityReferenceConstraintViolationException;
 import org.planqk.atlas.core.model.ApplicationArea;
 import org.planqk.atlas.core.repository.ApplicationAreaRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -88,6 +89,7 @@ public class ApplicationAreaServiceImpl implements ApplicationAreaService {
     }
 
     private void removeReferences(ApplicationArea applicationArea) {
-        applicationArea.getAlgorithms().forEach(algorithm -> algorithm.removeApplicationArea(applicationArea));
+        CollectionUtils.forEachOnCopy(applicationArea.getAlgorithms(),
+                algorithm -> algorithm.removeApplicationArea(applicationArea));
     }
 }

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/CloudServiceServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/CloudServiceServiceImpl.java
@@ -27,6 +27,7 @@ import org.planqk.atlas.core.model.SoftwarePlatform;
 import org.planqk.atlas.core.repository.CloudServiceRepository;
 import org.planqk.atlas.core.repository.ComputeResourceRepository;
 import org.planqk.atlas.core.repository.SoftwarePlatformRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -92,9 +93,9 @@ public class CloudServiceServiceImpl implements CloudServiceService {
     }
 
     private void removeReferences(@NonNull CloudService cloudService) {
-        cloudService.getSoftwarePlatforms().forEach(
+        CollectionUtils.forEachOnCopy(cloudService.getSoftwarePlatforms(),
                 softwarePlatform -> softwarePlatform.removeCloudService(cloudService));
-        cloudService.getProvidedComputeResources().forEach(
+        CollectionUtils.forEachOnCopy(cloudService.getProvidedComputeResources(),
                 computeResource -> computeResource.removeCloudService(cloudService));
     }
 

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ComputeResourceServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ComputeResourceServiceImpl.java
@@ -28,6 +28,7 @@ import org.planqk.atlas.core.model.SoftwarePlatform;
 import org.planqk.atlas.core.repository.CloudServiceRepository;
 import org.planqk.atlas.core.repository.ComputeResourceRepository;
 import org.planqk.atlas.core.repository.SoftwarePlatformRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -107,8 +108,8 @@ public class ComputeResourceServiceImpl implements ComputeResourceService {
 //        computeResource.getCloudServices().forEach(
 //                cloudService -> cloudService.removeComputeResource(computeResource));
 
-        computeResource.getProvidedComputingResourceProperties().forEach(computingResourceProperty ->
-                computeResourcePropertyService.delete(computingResourceProperty.getId()));
+        CollectionUtils.forEachOnCopy(computeResource.getProvidedComputingResourceProperties(),
+                property -> computeResourcePropertyService.delete(property.getId()));
     }
 
     @Override

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationServiceImpl.java
@@ -31,6 +31,7 @@ import org.planqk.atlas.core.repository.ComputeResourcePropertyRepository;
 import org.planqk.atlas.core.repository.ImplementationRepository;
 import org.planqk.atlas.core.repository.PublicationRepository;
 import org.planqk.atlas.core.repository.SoftwarePlatformRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -114,12 +115,12 @@ public class ImplementationServiceImpl implements ImplementationService {
         implementation.getRequiredComputeResourceProperties().forEach(computeResourcePropertyRepository::delete);
 
         // Remove links to publications
-        implementation.getPublications().forEach(publication ->
-                publication.removeImplementation(implementation));
+        CollectionUtils.forEachOnCopy(implementation.getPublications(),
+                publication -> publication.removeImplementation(implementation));
 
         // Remove links to software platforms
-        implementation.getSoftwarePlatforms().forEach(softwarePlatform ->
-                softwarePlatform.removeImplementation(implementation));
+        CollectionUtils.forEachOnCopy(implementation.getSoftwarePlatforms(),
+                softwarePlatform -> softwarePlatform.removeImplementation(implementation));
     }
 
     @Override

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/PublicationServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/PublicationServiceImpl.java
@@ -29,6 +29,7 @@ import org.planqk.atlas.core.model.Publication;
 import org.planqk.atlas.core.repository.AlgorithmRepository;
 import org.planqk.atlas.core.repository.ImplementationRepository;
 import org.planqk.atlas.core.repository.PublicationRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -91,9 +92,10 @@ public class PublicationServiceImpl implements PublicationService {
     }
 
     private void removeReferences(@NonNull Publication publication) {
-        publication.getAlgorithms().forEach(algorithm -> algorithm.removePublication(publication));
-
-        publication.getImplementations().forEach(implementation -> implementation.removePublication(publication));
+        CollectionUtils.forEachOnCopy(publication.getAlgorithms(),
+                algorithm -> algorithm.removePublication(publication));
+        CollectionUtils.forEachOnCopy(publication.getImplementations(),
+                implementation -> implementation.removePublication(publication));
     }
 
     @Override

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SoftwarePlatformServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SoftwarePlatformServiceImpl.java
@@ -30,6 +30,7 @@ import org.planqk.atlas.core.repository.CloudServiceRepository;
 import org.planqk.atlas.core.repository.ComputeResourceRepository;
 import org.planqk.atlas.core.repository.ImplementationRepository;
 import org.planqk.atlas.core.repository.SoftwarePlatformRepository;
+import org.planqk.atlas.core.util.CollectionUtils;
 import org.planqk.atlas.core.util.ServiceUtils;
 
 import lombok.AllArgsConstructor;
@@ -101,11 +102,11 @@ public class SoftwarePlatformServiceImpl implements SoftwarePlatformService {
     }
 
     private void removeReferences(@NonNull SoftwarePlatform softwarePlatform) {
-        softwarePlatform.getImplementations().forEach(
+        CollectionUtils.forEachOnCopy(softwarePlatform.getImplementations(),
                 implementation -> implementation.removeSoftwarePlatform(softwarePlatform));
-        softwarePlatform.getSupportedCloudServices().forEach(
+        CollectionUtils.forEachOnCopy(softwarePlatform.getSupportedCloudServices(),
                 cloudService -> cloudService.removeSoftwarePlatform(softwarePlatform));
-        softwarePlatform.getSupportedComputeResources().forEach(
+        CollectionUtils.forEachOnCopy(softwarePlatform.getSupportedComputeResources(),
                 computeResource -> computeResource.removeSoftwarePlatform(softwarePlatform));
     }
 

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/util/CollectionUtils.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/util/CollectionUtils.java
@@ -1,0 +1,24 @@
+package org.planqk.atlas.core.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class CollectionUtils {
+    /**
+     * Performs the given action for each element of the given @link Collection.
+     * To allow concurrent modifications the collection is copied before iterating over it.
+     *
+     * @param coll The collection to iterate over
+     * @param action The action to be performed for each element
+     */
+    public static <T> void forEachOnCopy(Collection<T> coll, Consumer<? super T> action) {
+        Objects.requireNonNull(coll);
+        Objects.requireNonNull(action);
+        final var copy = List.copyOf(coll);
+        for (T t : copy) {
+            action.accept(t);
+        }
+    }
+}


### PR DESCRIPTION
Custom removal methods such as `removeAlgorithm()` try to remove an element from both sides of its relationship.
This randomly fails as we're iterating over one of the two containers involved.

**Fixes**: #148
