### PR TITLE
Include all DB migration changelogs manually

### DIFF
--- a/org.planqk.atlas.core/src/main/resources/db/changelog-master.xml
+++ b/org.planqk.atlas.core/src/main/resources/db/changelog-master.xml
@@ -2,5 +2,12 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
-    <includeAll path="classpath:/db/changelog" />
+    <!--
+    <includeAll path="classpath:/db/changelog/" /> with a consistent naming scheme would be better,
+    but is unsupported right now.
+
+    The spring boot loader that's part of the executable JAR output doesn't seem
+    to support classpath directory listings, breaking includeAll.
+    -->
+    <include file="classpath:/db/changelog/2020-10-14-00-00-initial.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
It appears the 'executable jar/war' built via the Spring Boot maven plugin
doesn't support directory listings for classpath URIs, breaking the automatic
OpenAPI spec extraction.
