### PR TITLE
Only activate CloudStorageConfiguration in google-cloud profile

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/CloudStorageConfiguration.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/CloudStorageConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
-@Profile("!test")
+@Profile("google-cloud")
 @Primary
 @Configuration
 public class CloudStorageConfiguration {


### PR DESCRIPTION
#### Short Description
Disable CloudStorageConfiguration if google-cloud profile is not set to avoid exceptions without suited configuration
