### PR TITLE
define inverseTypeName and adapt port for db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
             POSTGRES_PASSWORD: planqk
             POSTGRES_DB: planqk
         ports:
-            - "5432:5432"
+            - "5060:5060"

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/AlgorithmRelationType.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/model/AlgorithmRelationType.java
@@ -30,4 +30,6 @@ import lombok.EqualsAndHashCode;
 public class AlgorithmRelationType extends HasId {
 
     private String name;
+
+    private String inverseTypeName;
 }

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmRelationTypeServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/AlgorithmRelationTypeServiceImpl.java
@@ -66,6 +66,7 @@ public class AlgorithmRelationTypeServiceImpl implements AlgorithmRelationTypeSe
         final var persistedAlgorithmRelationType = findById(algorithmRelationType.getId());
 
         persistedAlgorithmRelationType.setName(algorithmRelationType.getName());
+        persistedAlgorithmRelationType.setInverseTypeName(algorithmRelationType.getInverseTypeName());
 
         return algorithmRelationTypeRepository.save(persistedAlgorithmRelationType);
     }

--- a/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/services/AlgorithmRelationServiceTest.java
+++ b/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/services/AlgorithmRelationServiceTest.java
@@ -54,7 +54,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm sourceAlgorithm = getCreatedAlgorithm("sourceAlgorithmName");
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -74,7 +74,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         targetAlgorithm.setName("targetAlgorithmName");
         targetAlgorithm.setId(UUID.randomUUID());
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -87,7 +87,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm sourceAlgorithm = getCreatedAlgorithm("sourceAlgorithmName");
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -110,7 +110,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm sourceAlgorithm = getCreatedAlgorithm("sourceAlgorithmName");
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -121,7 +121,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         compareAlgorithmRelation.setId(persistedAlgorithmRelation.getId());
 
         String editDescription = "editedDescription";
-        var editedType = getCreatedAlgorithmRelationType("editedAlgorithmRelationTypeName");
+        var editedType = getCreatedAlgorithmRelationType("editedAlgorithmRelationTypeName", "editedInverseAlgorithmRelationTypeName");
         persistedAlgorithmRelation.setDescription(editDescription);
         persistedAlgorithmRelation.setAlgorithmRelationType(editedType);
 
@@ -139,6 +139,10 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
                 .isNotEqualTo(compareAlgorithmRelation.getAlgorithmRelationType().getName());
         assertThat(updatedAlgorithmRelation.getAlgorithmRelationType().getName())
                 .isEqualTo(editedType.getName());
+        assertThat(updatedAlgorithmRelation.getAlgorithmRelationType().getInverseTypeName())
+            .isNotEqualTo(compareAlgorithmRelation.getAlgorithmRelationType().getInverseTypeName());
+        assertThat(updatedAlgorithmRelation.getAlgorithmRelationType().getInverseTypeName())
+            .isEqualTo(editedType.getInverseTypeName());
         assertThat(updatedAlgorithmRelation.getSourceAlgorithm().getId())
                 .isEqualTo(compareAlgorithmRelation.getSourceAlgorithm().getId());
         assertThat(updatedAlgorithmRelation.getTargetAlgorithm().getId())
@@ -158,7 +162,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm sourceAlgorithm = getCreatedAlgorithm("sourceAlgorithmName");
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -184,7 +188,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm sourceAlgorithm = getCreatedAlgorithm("sourceAlgorithmName");
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -203,7 +207,7 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         Algorithm targetAlgorithm = getCreatedAlgorithm("targetAlgorithmName");
         Algorithm checkAlgorithm = getCreatedAlgorithm("checkAlgorithmName");
 
-        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName");
+        var algorithmRelationType = getCreatedAlgorithmRelationType("algorithmRelationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelation algorithmRelation = buildAlgorithmRelation(
                 sourceAlgorithm, targetAlgorithm, algorithmRelationType, "description");
@@ -230,9 +234,10 @@ public class AlgorithmRelationServiceTest extends AtlasDatabaseTestBase {
         return algorithmService.create(algorithm);
     }
 
-    private AlgorithmRelationType getCreatedAlgorithmRelationType(String name) {
+    private AlgorithmRelationType getCreatedAlgorithmRelationType(String name, String inverseTypeName) {
         AlgorithmRelationType algorithmRelationType = new AlgorithmRelationType();
         algorithmRelationType.setName(name);
+        algorithmRelationType.setInverseTypeName(inverseTypeName);
         return algorithmRelationTypeService.create(algorithmRelationType);
     }
 }

--- a/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/services/AlgorithmRelationTypeServiceTest.java
+++ b/org.planqk.atlas.core/src/test/java/org/planqk/atlas/core/services/AlgorithmRelationTypeServiceTest.java
@@ -54,19 +54,20 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
 
     @Test
     void createAlgorithmRelationType() {
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelationType storedRelationType = algorithmRelationTypeService.create(relationType);
 
         assertThat(storedRelationType.getId()).isNotNull();
         assertThat(storedRelationType.getName()).isEqualTo(relationType.getName());
+        assertThat(storedRelationType.getInverseTypeName()).isEqualTo(relationType.getInverseTypeName());
     }
 
     @Test
     void findAllAlgorithmRelationTypes() {
-        AlgorithmRelationType relationType1 = getFullAlgorithmRelationType("relationTypeName1");
+        AlgorithmRelationType relationType1 = getFullAlgorithmRelationType("relationTypeName1", "inverseAlgorithmRelationTypeName1");
         algorithmRelationTypeService.create(relationType1);
-        AlgorithmRelationType relationType2 = getFullAlgorithmRelationType("relationTypeName2");
+        AlgorithmRelationType relationType2 = getFullAlgorithmRelationType("relationTypeName2", "inverseAlgorithmRelationTypeName2");
         algorithmRelationTypeService.create(relationType2);
 
         List<AlgorithmRelationType> algorithmRelationTypes = algorithmRelationTypeService.findAll(Pageable.unpaged()).getContent();
@@ -82,7 +83,7 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
 
     @Test
     void findAlgorithmRelationTypeById_ElementFound() {
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelationType storedRelationType = algorithmRelationTypeService.create(relationType);
 
@@ -90,11 +91,12 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
 
         assertThat(storedRelationType.getId()).isNotNull();
         assertThat(storedRelationType.getName()).isEqualTo(relationType.getName());
+        assertThat(storedRelationType.getInverseTypeName()).isEqualTo(relationType.getInverseTypeName());
     }
 
     @Test
     void UpdateAlgorithmRelationType_ElementNotFound() {
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
         relationType.setId(UUID.randomUUID());
         assertThrows(NoSuchElementException.class, () ->
                 algorithmRelationTypeService.update(relationType));
@@ -102,19 +104,23 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
 
     @Test
     void updateAlgorithmRelationType_ElementFound() {
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
-        AlgorithmRelationType compareRelationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
+        AlgorithmRelationType compareRelationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
 
         AlgorithmRelationType storedRelationType = algorithmRelationTypeService.create(relationType);
         compareRelationType.setId(storedRelationType.getId());
         String editName = "editedRelationTypeName";
+        String editInverseName = "editedinverseAlgorithmRelationTypeName";
         storedRelationType.setName(editName);
+        storedRelationType.setInverseTypeName(editInverseName);
         storedRelationType = algorithmRelationTypeService.update(storedRelationType);
 
         assertThat(storedRelationType.getId()).isNotNull();
         assertThat(storedRelationType.getId()).isEqualTo(compareRelationType.getId());
         assertThat(storedRelationType.getName()).isNotEqualTo(compareRelationType.getName());
         assertThat(storedRelationType.getName()).isEqualTo(editName);
+        assertThat(storedRelationType.getInverseTypeName()).isNotEqualTo(compareRelationType.getInverseTypeName());
+        assertThat(storedRelationType.getInverseTypeName()).isEqualTo(editInverseName);
     }
 
     @Test
@@ -129,7 +135,7 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
         targetAlgorithm.setComputationModel(ComputationModel.CLASSIC);
         Algorithm storedTargetAlgorithm = algorithmService.create(targetAlgorithm);
 
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
         AlgorithmRelationType storedRelationType = algorithmRelationTypeService.create(relationType);
 
         AlgorithmRelation algorithmRelation = new AlgorithmRelation();
@@ -147,7 +153,7 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
 
     @Test
     void deleteAlgorithmRelationType_Unused() {
-        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName");
+        AlgorithmRelationType relationType = getFullAlgorithmRelationType("relationTypeName", "inverseAlgorithmRelationTypeName");
         AlgorithmRelationType storedRelationType = algorithmRelationTypeService.create(relationType);
 
         assertDoesNotThrow(() -> algorithmRelationTypeService.findById(storedRelationType.getId()));
@@ -158,9 +164,10 @@ public class AlgorithmRelationTypeServiceTest extends AtlasDatabaseTestBase {
                 algorithmRelationTypeService.findById(storedRelationType.getId()));
     }
 
-    private AlgorithmRelationType getFullAlgorithmRelationType(String typeName) {
+    private AlgorithmRelationType getFullAlgorithmRelationType(String typeName, String inverseTypeName) {
         AlgorithmRelationType algorithmRelationType = new AlgorithmRelationType();
         algorithmRelationType.setName(typeName);
+        algorithmRelationType.setInverseTypeName(inverseTypeName);
         return algorithmRelationType;
     }
 }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationTypeDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationTypeDto.java
@@ -43,4 +43,6 @@ public class AlgorithmRelationTypeDto implements Identifyable {
     @NotNull(groups = {ValidationGroups.Update.class, ValidationGroups.Create.class},
              message = "RelationType-Name must not be null!")
     private String name;
+
+    private String inverseTypeName;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         * Default database in non-Docker development environments
         * Target database for Liquibase operations, such as diff or update
         -->
-        <db.url>jdbc:postgresql://localhost:5432/planqk</db.url>
+        <db.url>jdbc:postgresql://localhost:5060/planqk</db.url>
         <db.username>planqk</db.username>
         <db.password>planqk</db.password>
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>


### PR DESCRIPTION
Add inverseTypeName to AlgorithmRelationTypes.
Additionally, fix db ports to 5060.

Tackles https://github.com/UST-QuAntiL/qc-atlas/issues/188
