### PR TITLE
rename algoRelationType to algorithmRelationType

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmRelationDto.java
@@ -51,7 +51,7 @@ public class AlgorithmRelationDto implements Identifyable {
              message = "Target Algorithm id must not be null!")
     private UUID targetAlgorithmId;
 
-    @JsonProperty("algoRelationType")
+    @JsonProperty("algorithmRelationType")
     @RequiresID(groups = {ValidationGroups.Update.class, ValidationGroups.Create.class},
                 message = "AlgorithmRelationType must have a type with an ID!")
     @NotNull(groups = {ValidationGroups.Update.class, ValidationGroups.Create.class},

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmRelationControllerTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/controller/AlgorithmRelationControllerTest.java
@@ -185,7 +185,7 @@ public class AlgorithmRelationControllerTest {
         ).andExpect(jsonPath("$.id").isEmpty())
                 .andExpect(jsonPath("$.sourceAlgorithmId").value(sourceAlgorithm.getId().toString()))
                 .andExpect(jsonPath("$.targetAlgorithmId").value(targetAlgorithm.getId().toString()))
-                .andExpect(jsonPath("$.algoRelationType.id").value(type.getId().toString()))
+                .andExpect(jsonPath("$.algorithmRelationType.id").value(type.getId().toString()))
                 .andExpect(status().isCreated());
     }
 
@@ -263,7 +263,7 @@ public class AlgorithmRelationControllerTest {
         ).andExpect(jsonPath("$.id").value(algorithmRelation.getId().toString()))
                 .andExpect(jsonPath("$.sourceAlgorithmId").value(sourceAlgorithm.getId().toString()))
                 .andExpect(jsonPath("$.targetAlgorithmId").value(targetAlgorithm.getId().toString()))
-                .andExpect(jsonPath("$.algoRelationType.id").value(type.getId().toString()))
+                .andExpect(jsonPath("$.algorithmRelationType.id").value(type.getId().toString()))
                 .andExpect(status().isOk());
     }
 
@@ -365,7 +365,7 @@ public class AlgorithmRelationControllerTest {
                 .andExpect(jsonPath("$.id").value(algorithmRelation.getId().toString()))
                 .andExpect(jsonPath("$.sourceAlgorithmId").value(sourceAlgorithm.getId().toString()))
                 .andExpect(jsonPath("$.targetAlgorithmId").value(targetAlgorithm.getId().toString()))
-                .andExpect(jsonPath("$.algoRelationType.id").value(type.getId().toString()))
+                .andExpect(jsonPath("$.algorithmRelationType.id").value(type.getId().toString()))
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
To be uniform with the platform, renaming of algoRelationType to algorithmRelationType.