### PR TITLE
Fix/swagger model for quantum and classic algos impls

### DIFF
--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
@@ -43,18 +43,6 @@ public class SwaggerConfiguration {
     // AlgorithmDto -- (via oneOf) --> ClassicAlgorithmDto -- (extends) --> AlgorithmDto
 
     @Schema(
-            name = "AlgorithmDto",
-            description = "Either a quantum or a classic algorithm",
-            oneOf = {ClassicAlgorithmDto.class, QuantumAlgorithmDto.class},
-            discriminatorMapping = {
-                    @DiscriminatorMapping(value = "CLASSIC", schema = ClassicAlgorithmDto.class),
-                    @DiscriminatorMapping(value = "QUANTUM", schema = QuantumAlgorithmDto.class),
-            }
-    )
-    private static class AlgorithmSchema {
-    }
-
-    @Schema(
             name = "ImplementationDto",
             description = "Either a quantum or a classic implementation",
             oneOf = {ClassicImplementationDto.class, QuantumImplementationDto.class},

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/SwaggerConfiguration.java
@@ -44,6 +44,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Configuration
 public class SwaggerConfiguration {
 
+    /**
+     * ModelConverter that allows overriding {@link io.swagger.v3.oas.models.media.Schema} objects for Java classes.
+     * Required for the different models (Quantum, Hybrid, or Classic) of AlgorithmDto and ImplementationDto,
+     * see private classes AlgorithmSchema and ImplementationSchema below.
+     */
     @Bean
     @Lazy(false)
     public OverrideModelConverter overrideModelConverter() {

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
@@ -32,8 +32,6 @@ import org.planqk.atlas.web.utils.ValidationGroups;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -46,17 +44,6 @@ import lombok.NoArgsConstructor;
 @JsonSubTypes({@JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "QUANTUM"),
                       @JsonSubTypes.Type(value = ClassicAlgorithmDto.class, name = "CLASSIC"),
                       @JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "HYBRID")})
-@Schema(
-    name = "AlgorithmDto",
-    description = "Either a quantum, hybrid or a classic algorithm",
-    discriminatorProperty = "computationModel",
-    oneOf = {ClassicAlgorithmDto.class, QuantumAlgorithmDto.class},
-    discriminatorMapping = {
-        @DiscriminatorMapping(value = "CLASSIC", schema = ClassicAlgorithmDto.class),
-        @DiscriminatorMapping(value = "QUANTUM", schema = QuantumAlgorithmDto.class),
-        @DiscriminatorMapping(value = "HYBRID", schema = QuantumAlgorithmDto.class)
-    }
-)
 public class AlgorithmDto implements Identifyable {
     @NotNull(groups = {ValidationGroups.IDOnly.class}, message = "An id is required to perform an update")
     @Null(groups = {ValidationGroups.Create.class}, message = "The id must be null for creating an algorithm")

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/AlgorithmDto.java
@@ -32,6 +32,8 @@ import org.planqk.atlas.web.utils.ValidationGroups;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -44,6 +46,17 @@ import lombok.NoArgsConstructor;
 @JsonSubTypes({@JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "QUANTUM"),
                       @JsonSubTypes.Type(value = ClassicAlgorithmDto.class, name = "CLASSIC"),
                       @JsonSubTypes.Type(value = QuantumAlgorithmDto.class, name = "HYBRID")})
+@Schema(
+    name = "AlgorithmDto",
+    description = "Either a quantum, hybrid or a classic algorithm",
+    discriminatorProperty = "computationModel",
+    oneOf = {ClassicAlgorithmDto.class, QuantumAlgorithmDto.class},
+    discriminatorMapping = {
+        @DiscriminatorMapping(value = "CLASSIC", schema = ClassicAlgorithmDto.class),
+        @DiscriminatorMapping(value = "QUANTUM", schema = QuantumAlgorithmDto.class),
+        @DiscriminatorMapping(value = "HYBRID", schema = QuantumAlgorithmDto.class)
+    }
+)
 public class AlgorithmDto implements Identifyable {
     @NotNull(groups = {ValidationGroups.IDOnly.class}, message = "An id is required to perform an update")
     @Null(groups = {ValidationGroups.Create.class}, message = "The id must be null for creating an algorithm")

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
@@ -48,7 +48,7 @@ public class QuantumAlgorithmDto extends AlgorithmDto {
     private String speedUp;
 
     @Override
-    @Schema(type = "string", allowableValues = {"QUANTUM"})
+    @Schema(type = "string", allowableValues = {"QUANTUM", "HYBRID"})
     public ComputationModel getComputationModel() {
         return super.getComputationModel();
     }

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/dtos/QuantumAlgorithmDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the qc-atlas contributors.
+ * Copyright (c) 2020-2021 the qc-atlas contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the qc-atlas contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.planqk.atlas.web.utils;
+
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.ResolvedType;
+import com.fasterxml.jackson.databind.JavaType;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * ModelConverter that allows overriding {@link Schema} objects for Java classes.
+ */
+@RequiredArgsConstructor
+public class OverrideModelConverter implements ModelConverter {
+    private final Map<Type, Type> contentOverrides;
+
+    private static Class<?> classFromType(Type type) {
+        if (type instanceof Class<?>)
+            return (Class<?>) type;
+        if (type instanceof ResolvedType)
+            return ((ResolvedType) type).getRawClass();
+        return null;
+    }
+
+    @Override
+    public Schema resolve(AnnotatedType annotatedType, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        final JavaType type;
+        if (annotatedType.getType() instanceof JavaType) {
+            type = (JavaType) annotatedType.getType();
+        } else {
+            type = Json.mapper().constructType(annotatedType.getType());
+        }
+        if (type != null) {
+            annotatedType.type(applyOverrides(type));
+        }
+        if (chain.hasNext()) {
+            return chain.next().resolve(annotatedType, context, chain);
+        } else {
+            return null;
+        }
+    }
+
+    private Type applyOverrides(Type type) {
+        final var clazz = classFromType(type);
+        if (clazz != null)
+            return contentOverrides.getOrDefault(clazz, type);
+        return type;
+    }
+}

--- a/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
+++ b/org.planqk.atlas.web/src/main/java/org/planqk/atlas/web/utils/OverrideModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the qc-atlas contributors.
+ * Copyright (c) 2020-2021 the qc-atlas contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/OverrideModelConverterTest.java
+++ b/org.planqk.atlas.web/src/test/java/org/planqk/atlas/web/utils/OverrideModelConverterTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2021 the qc-atlas contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+    package org.planqk.atlas.web.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class OverrideModelConverterTest {
+    @Test
+    void verifySchemaOverride() {
+        final var converters = new ModelConverters();
+        converters.addConverter(new OverrideModelConverter(Map.of(SimpleDto.class, SimpleDtoOverride.class)));
+
+        final var wrapped = converters.resolveAsResolvedSchema(new AnnotatedType().type(SimpleDto.class)
+            .resolveAsRef(false));
+        assertEquals(List.of("otherField"), wrapped.schema.getRequired());
+        assertEquals(1, wrapped.schema.getProperties().size());
+    }
+
+    @NoArgsConstructor
+    @Data
+    private static class SimpleDto {
+        @NotNull
+        private String notNull;
+
+        private String nullable;
+    }
+
+    @NoArgsConstructor
+    @Data
+    private static class SimpleDtoOverride {
+        @NotNull
+        private String otherField;
+    }
+}


### PR DESCRIPTION
For presenting the Quantum/Classic Algorithm/Implementation models in Swagger UI correct, the OverrideModelConverter was reconstructed from a previous merge.
In addition, HYBRID algorithms were added as case for QuantumAlgorithmDto.

Solves #198 