### PR TITLE
Add default values for multipart config to Docker container

### DIFF
--- a/.docker/application.properties.tpl
+++ b/.docker/application.properties.tpl
@@ -24,8 +24,8 @@ spring.jackson.serialization.write-dates-as-timestamps=false
 server.servlet.contextPath=/atlas
 # Max file upload size
 spring.servlet.multipart.enabled=true
-spring.servlet.multipart.max-file-size={{.Env.UPLOAD_FILE_SIZE}}
-spring.servlet.multipart.max-request-size={{.Env.UPLOAD_FILE_SIZE}}
+spring.servlet.multipart.max-file-size={{ default .Env.UPLOAD_FILE_SIZE "150MB"}}
+spring.servlet.multipart.max-request-size={{ default .Env.UPLOAD_FILE_SIZE "150MB"}}
 
 # Winery
 org.planqk.atlas.winery.protocol={{.Env.WINERY_PROTOCOL}}


### PR DESCRIPTION
#### Short Description
Use 150 MB as a default value for `spring.servlet.multipart.max-file-size`  and `spring.servlet.multipart.max-request-size` in the Docker container.


Signed-off-by: Marvin Bechtold <marvin.bechtold.dev@gmail.com>
