### PR TITLE
Fix unique file name constraint

### DIFF
--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/FileServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/FileServiceImpl.java
@@ -63,7 +63,7 @@ public class FileServiceImpl implements FileService {
             }
 
             createdFile.setMimeType(contentType);
-            createdFile.setFileURL(file.getOriginalFilename());
+            createdFile.setFileURL(UUID.randomUUID().toString());
 
             final FileData fileData = new FileData();
             fileData.setData(inputStream.readAllBytes());

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationPackageServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/ImplementationPackageServiceImpl.java
@@ -118,6 +118,11 @@ public class ImplementationPackageServiceImpl implements ImplementationPackageSe
     public File addFileToImplementationPackage(UUID implementationPackageId, MultipartFile multipartFile) {
         final ImplementationPackage implementationPackage =
                 ServiceUtils.findById(implementationPackageId, ImplementationPackage.class, implementationPackageRepository);
+
+        if (implementationPackage.getFile() != null) {
+            throw new RuntimeException("the implementation package already has a file");
+        }
+        
         final File file = fileService.create(multipartFile);
         implementationPackage.setFile(file);
         implementationPackageRepository.save(implementationPackage);

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SolutionServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SolutionServiceImpl.java
@@ -85,6 +85,11 @@ public class SolutionServiceImpl implements SolutionService {
     public File addFileToSolution(UUID solutionId, MultipartFile multipartFile) {
         final Solution solution =
                 ServiceUtils.findById(solutionId, Solution.class, solutionRepository);
+
+        if (solution.getFile() != null) {
+            return solution.getFile();
+        }
+
         final File file = fileService.create(multipartFile);
         solution.setFile(file);
         solutionRepository.save(solution);

--- a/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SolutionServiceImpl.java
+++ b/org.planqk.atlas.core/src/main/java/org/planqk/atlas/core/services/SolutionServiceImpl.java
@@ -87,7 +87,7 @@ public class SolutionServiceImpl implements SolutionService {
                 ServiceUtils.findById(solutionId, Solution.class, solutionRepository);
 
         if (solution.getFile() != null) {
-            return solution.getFile();
+            throw new RuntimeException("the solution already has a file");
         }
 
         final File file = fileService.create(multipartFile);


### PR DESCRIPTION
Fixes:
- each uploaded file had to have a unique file name when using the database as file store
- error handling when a solution already has a file